### PR TITLE
Web版（Streamlit）追加・デプロイ対応とCLAUDE.md整備

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,18 @@ streamlit run streamlit_app.py
 
 ここに修正・変更の内容を追記していく。新しいものを上に追加すること。
 
+- **Streamlit 版のレスポンシブデザイン対応**: PC / タブレット / スマホの各画面幅で
+  見やすくなるよう `streamlit_app.py` を調整。
+  - `_inject_responsive_css()` を追加し、`main()` 冒頭（`set_page_config` 直後）で注入。
+    CSS メディアクエリで、見出しは `clamp()` によりビューポート幅に応じて滑らかに
+    スケール、タブは折り返さず横スクロール（`overflow-x:auto`/`white-space:nowrap`）、
+    タブレット（≤1024px）／スマホ（≤640px）で本文余白を段階的に縮小、スマホでは
+    タブ文字を縮小し matplotlib 画像をコンテナ幅にフィットさせる。
+  - 図描画を `st.pyplot(fig, use_container_width=True)` に変更し、列幅に追従させる。
+  - `set_page_config` に `initial_sidebar_state="auto"`（狭幅で自動折りたたみ）。
+  - 検証: `py_compile` OK / Streamlit health=ok・トップ200 / `AppTest` 例外0・
+    タイトル描画・レスポンシブ CSS（`clamp(`＋`@media`）の注入を確認。
+
 - **Web デプロイ対応（Streamlit 化）**: Tkinter GUI は Vercel/Netlify で動かせないため、
   ブラウザ利用できる Streamlit 版を追加した。デスクトップ版は維持。
   - 新規: `streamlit_app.py`（Web エントリ）、`core/charts.py`（Figure/結果テーブル生成の

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,11 @@ streamlit run streamlit_app.py
 
 ここに修正・変更の内容を追記していく。新しいものを上に追加すること。
 
+- **Streamlit デプロイ手順書を追加**: `DEPLOY_STREAMLIT.md` を新規作成。Streamlit
+  Community Cloud でのデプロイ手順（対象ブランチへのコード配置、Create app での
+  Repository/Branch/Main file=`streamlit_app.py` 指定、動作確認、更新の自動再デプロイ、
+  無料枠の制約）と、Render/Railway/Fly（Dockerfile）の代替手段を 1 ファイルにまとめた。
+
 - **Streamlit 版のレスポンシブデザイン対応**: PC / タブレット / スマホの各画面幅で
   見やすくなるよう `streamlit_app.py` を調整。
   - `_inject_responsive_css()` を追加し、`main()` 冒頭（`set_page_config` 直後）で注入。

--- a/DEPLOY_STREAMLIT.md
+++ b/DEPLOY_STREAMLIT.md
@@ -1,0 +1,104 @@
+# Streamlit デプロイ手順（DEPLOY_STREAMLIT.md）
+
+F1 Data Dashboard の **Web 版（`streamlit_app.py`）** を Streamlit Community Cloud に
+デプロイするための手順をまとめたファイル。上から順にやれば公開できる。
+
+---
+
+## 0. 前提（必要なもの）
+
+- GitHub アカウント（このリポジトリ `tabear25/formula1_dashboard` にアクセスできること）
+- Streamlit Community Cloud アカウント（GitHub でサインインするだけ・無料）
+- 特別な API キーや課金は **不要**（FastF1 は公開データ）
+
+---
+
+## 1. デプロイするコードを GitHub の対象ブランチに置く ⚠️最重要
+
+Web 版のファイル（`streamlit_app.py`, `core/`, `.streamlit/config.toml` など）は
+作業ブランチ `claude/claude-md-updates-w8v1ze` にある。**`main` にはまだ無い**ので、
+次のどちらかを行う。
+
+- **（推奨）`main` にマージする** → デプロイ画面で branch = `main` を選べる
+- もしくはデプロイ画面で branch にこの作業ブランチを直接指定する
+
+確認: GitHub 上で対象ブランチに以下が存在すること。
+- `streamlit_app.py`（メインファイル）
+- `requirements.txt`
+- `core/charts.py` / `core/data.py`
+- `.streamlit/config.toml`
+
+---
+
+## 2. 必要ファイルのチェック（すでに用意済み）
+
+| ファイル | 役割 | 状態 |
+|---|---|---|
+| `streamlit_app.py` | Web 版エントリポイント（Main file に指定） | ✅ |
+| `requirements.txt` | 依存（streamlit / fastf1 / pandas / matplotlib / seaborn） | ✅ |
+| `.streamlit/config.toml` | ダークテーマ等の設定 | ✅ |
+
+追加で作る必要のあるファイルは基本ない。Streamlit Cloud が `requirements.txt` を
+自動でインストールする。
+
+---
+
+## 3. Streamlit Community Cloud でデプロイ
+
+1. https://share.streamlit.io にアクセスし、**GitHub でサインイン**（リポジトリ連携を認可）。
+2. **「Create app」**（または「New app」→「Deploy a public app from GitHub」）をクリック。
+3. 次の 3 項目を指定する。
+
+   | 項目 | 値 |
+   |---|---|
+   | Repository | `tabear25/formula1_dashboard` |
+   | Branch | `main`（または作業ブランチ） |
+   | Main file path | `streamlit_app.py` |
+
+4. （任意）**Advanced settings** で Python バージョンを選択（3.9 以上推奨。未指定でも可）。
+5. **「Deploy」** を押す。初回ビルド（依存インストール）に数分かかる。
+6. 発行された URL（`https://<app-name>.streamlit.app`）でアプリが開けば完了。
+
+> Secrets（環境変数）は不要。キャッシュ先 `FASTF1_CACHE` も未設定なら一時ディレクトリを
+> 使う実装になっているため、設定しなくてよい。
+
+---
+
+## 4. 動作確認
+
+1. 公開 URL を開く。
+2. サイドバーで **開催年 → グランプリ → セッション** を選び「セッションを読み込む」。
+   - 初回はデータ DL のため時間がかかる（2 回目以降はキャッシュで高速）。
+3. ドライバーを選び、各タブ（Map / Results / Telemetry / 各種比較）が表示されれば成功。
+
+---
+
+## 5. 更新の反映
+
+対象ブランチに push すると Streamlit Cloud が**自動で再デプロイ**する。
+手動で再起動したい場合は、アプリ管理画面の「Reboot」から行う。
+
+---
+
+## 6. 制約・注意点（無料枠）
+
+- **メモリ約 1GB**: FastF1 のフルテレメトリ読み込みはメモリを消費するため、
+  非常に大きいセッションで稀に落ちることがある。
+- **スリープ**: 一定時間アクセスが無いとアプリが休止する。復帰直後と初回ロードは遅い
+  （キャッシュは揮発するため）。
+- **公開範囲**: 無料枠の公開アプリは URL を知っていれば誰でも閲覧可。
+  リポジトリ自体は private でもデプロイ可能。
+
+---
+
+## 代替: Render / Railway / Fly.io（Docker）
+
+常時起動やメモリ増強が必要なら、リポジトリ同梱の **`Dockerfile`** でデプロイできる。
+`$PORT` は各プラットフォームが自動注入する。
+
+起動コマンド（Dockerfile に定義済み）:
+```
+streamlit run streamlit_app.py --server.port=$PORT --server.address=0.0.0.0
+```
+
+※ Vercel / Netlify は Python の常時起動サーバーや重い依存に不向きなため非対応。

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -43,7 +43,11 @@ def _setup_mpl():
 
 
 def _show_fig(builder, *args):
-    """Figure ビルダーを実行し、結果を描画する。データ無しは警告表示。"""
+    """Figure ビルダーを実行し、結果を描画する。データ無しは警告表示。
+
+    `use_container_width=True` で図を列幅に追従させ、画面幅（PC/タブレット/スマホ）に
+    応じて自動でスケールさせる（レスポンシブ）。
+    """
     try:
         fig = builder(*args)
     except ChartDataError as e:
@@ -52,11 +56,57 @@ def _show_fig(builder, *args):
     except Exception as e:  # noqa: BLE001 - 予期せぬ描画エラーも UI に出す
         st.error(f"描画中にエラーが発生しました: {e}")
         return
-    st.pyplot(fig)
+    st.pyplot(fig, use_container_width=True)
+
+
+def _inject_responsive_css():
+    """画面幅に応じてレイアウトを最適化するレスポンシブ CSS を注入する。
+
+    Streamlit は既定でも幅に追従するが、スマホ／タブレットでの可読性を上げるため
+    余白・見出しサイズ・タブの折り返し等を CSS のメディアクエリで調整する。
+    """
+    st.markdown(
+        """
+        <style>
+        /* 見出しはビューポート幅に応じて滑らかにスケール（clamp でレスポンシブ） */
+        h1 { font-size: clamp(1.4rem, 4vw, 2.2rem) !important; }
+        h2 { font-size: clamp(1.15rem, 3vw, 1.6rem) !important; }
+        h3 { font-size: clamp(1.0rem, 2.6vw, 1.3rem) !important; }
+
+        /* タブが多くてもスマホで折り返さず横スクロールで全件アクセスできるように */
+        .stTabs [data-baseweb="tab-list"] {
+            overflow-x: auto;
+            flex-wrap: nowrap;
+            scrollbar-width: thin;
+        }
+        .stTabs [data-baseweb="tab"] { white-space: nowrap; }
+
+        /* タブレット以下: 本文余白を詰めて描画領域を最大化 */
+        @media (max-width: 1024px) {
+            .block-container { padding-left: 2rem; padding-right: 2rem; }
+        }
+
+        /* スマホ: さらに余白を詰め、タブ文字を縮小して片手操作に最適化 */
+        @media (max-width: 640px) {
+            .block-container {
+                padding-top: 2.5rem;
+                padding-left: 0.8rem;
+                padding-right: 0.8rem;
+            }
+            .stTabs [data-baseweb="tab"] { font-size: 0.8rem; padding: 0 0.5rem; }
+            /* 画像（matplotlib 図）は常にコンテナ幅にフィット */
+            div[data-testid="stImage"] img { width: 100% !important; height: auto !important; }
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
 
 
 def main():
-    st.set_page_config(page_title=APP_TITLE, page_icon="🏁", layout="wide")
+    st.set_page_config(page_title=APP_TITLE, page_icon="🏁", layout="wide",
+                       initial_sidebar_state="auto")
+    _inject_responsive_css()
     _setup_mpl()
 
     st.title("🏁 F1 Data Dashboard")


### PR DESCRIPTION
## 概要

ブラウザから利用できる **Web 版（Streamlit）** を追加し、Streamlit Cloud / Render 等へ
デプロイできるようにした。デスクトップ（Tkinter）版は維持。あわせて開発ガイド
`CLAUDE.md` とデプロイ手順書を整備。

Tkinter GUI は Vercel/Netlify で動かせないため、Python 対応 PaaS（Streamlit Cloud /
Render / Railway / Fly.io）向けの構成にしている。

## 主な変更

### Web 版（Streamlit）
- `streamlit_app.py`: Web エントリポイント。サイドバーで 年→GP→セッション→ドライバーを
  選択し、各タブ（Map / Results / Telemetry / 各種比較）を表示。
- `core/charts.py`: matplotlib Figure / 結果テーブルを生成する **フレームワーク非依存の
  共有コア**（`pyplot`・`tkinter` 非依存、データ無しは `ChartDataError`）。
  Tkinter 版・Streamlit 版の双方から呼ぶ単一の真実のソース。
- `core/data.py`: Streamlit キャッシュ付き FastF1 取得アダプタ
  （`st.cache_data` / `st.cache_resource`、キャッシュ先は `FASTF1_CACHE` で指定可）。
- `.streamlit/config.toml`（ダークテーマ）、`Dockerfile`（Render/Railway/Fly 用）。
- `tabs/*.py`: 図の組み立てを `core/charts` に委譲（埋め込みは従来どおり
  `FigureCanvasTkAgg`／Treeview）。
- `requirements.txt` に `streamlit` を追加。

### レスポンシブ対応
- `streamlit_app.py` に `_inject_responsive_css()` を追加。見出しの `clamp()` スケール、
  タブの横スクロール、タブレット/スマホ向けの余白・文字調整。
- 図描画を `st.pyplot(fig, use_container_width=True)` に変更し列幅へ追従。

### ドキュメント / 整備
- `CLAUDE.md`: プロジェクトガイドと変更履歴。「修正・変更はすべて CLAUDE.md に反映する」
  ルールを明記。
- `DEPLOY_STREAMLIT.md`: Streamlit Community Cloud でのデプロイ手順を 1 ファイルにまとめた
  （対象ブランチへの配置、Create app の指定項目、動作確認、無料枠の制約、Docker 代替）。
- `main.py`: 廃止済み `setup_mpl(misc_mpl_mods=...)` 引数を削除し `FutureWarning` を解消。

## 検証

- 全ファイル `py_compile` OK。
- デスクトップ版: Xvfb 上でコード 0 起動（リグレッション無し）。
- Web 版: Streamlit health=ok・トップ 200、`AppTest` 例外 0・タイトル描画・レスポンシブ
  CSS 注入を確認。
- 実セッションのデータ描画はコードスペースの外向き通信制限により未確認（スケジュール取得は
  成功）。実データ確認はデプロイ環境／ローカルを推奨。

## デプロイ

マージ後、`DEPLOY_STREAMLIT.md` に従い Streamlit Cloud で
Main file = `streamlit_app.py` を指定すれば公開できる。

https://claude.ai/code/session_01F2rGNK3ye4yyrVgBfi2QYL

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2rGNK3ye4yyrVgBfi2QYL)_