### PR TITLE
Enable PITWALL deployment to PaaS (Render/Railway/Fly)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,23 @@ GP＋セッション選択 → service.load_session_async(year, gp, ses)      �
 
 ここに修正・変更の内容を追記していく。新しいものを上に追加すること。
 
+- **PITWALL を PaaS（Render）にデプロイ可能化**: 「ローカルの `py server.py` と同じ
+  デザインを Web でも見たい」という要望に対応。Streamlit 版と PITWALL は別実装
+  （Streamlit=matplotlib 静止画を標準UIに配置／PITWALL=自前 SVG のインタラクティブ描画）
+  のため、同一デザインを得るには PITWALL 自体をデプロイするのが唯一の方法。
+  - `server.py`: `main()` を `$PORT` / `$HOST` 環境変数と `--host` 引数に対応させ、
+    キャッシュ先を `FASTF1_CACHE` 環境変数優先（未設定は従来 `config.CACHE_DIR`）に。
+    ブラウザ自動起動はローカルのループバック時のみに限定（PaaS では開かない）。
+    ローカルの `py server.py` の挙動は不変（既定 `127.0.0.1:8380`＋自動起動）。
+  - 新規 `render.yaml`（Render Blueprint。runtime=python / start=`python server.py
+    --host 0.0.0.0 --port $PORT --no-browser` / `FASTF1_CACHE=/tmp/f1_cache`）。
+  - 新規 `DEPLOY_PITWALL.md`（Render 手順＋Vercel/Netlify が不可な理由＋Railway/Fly 代替＋
+    無料枠の制約: スリープ／`/tmp` 揮発でキャッシュ消失／512MB メモリ）。
+  - Vercel/Netlify は常駐プロセス＋インメモリLRU＋バックグラウンドロードと相性が悪く不可。
+    常駐プロセス対応の Render/Railway/Fly を使う。
+  - 検証: `py_compile` OK ／ 引数・環境変数解決を確認 ／ `--host 0.0.0.0 --port $PORT`
+    で実起動し `/`・`styles.css`・`js/app.js` が 200、`FASTF1_CACHE` 反映をログで確認。
+
 - **Web版 PITWALL を追加**: `server.py`（stdlib http.server の JSON API、追加 pip 依存なし）+
   `web/`（vanilla JS SPA・自前SVG描画）+ `start_pitwall.cmd`。タブ＝ラップチャート
   （davidor/formula1-lap-charts のオマージュ）/ ギャップ（リーダー基準・勝者平均基準）/

--- a/DEPLOY_PITWALL.md
+++ b/DEPLOY_PITWALL.md
@@ -1,0 +1,89 @@
+# PITWALL デプロイ手順（DEPLOY_PITWALL.md）
+
+**ローカルでサーバを立てたときと同じデザイン**（`server.py` + `web/` の PITWALL）を
+そのまま Web に公開するための手順。Streamlit 版とは別アプリで、見た目・インタラクションは
+ローカルの PITWALL と**完全に一致**する（同じフロントエンドを配信するため）。
+
+---
+
+## なぜ Vercel / Netlify では動かないのか
+
+PITWALL は「プロセス常駐型の HTTP サーバ（stdlib `http.server`）＋セッションを
+バックグラウンドスレッドでロード＋インメモリの LRU キャッシュ（2件保持）」という構造。
+Vercel / Netlify はサーバーレス（リクエストごとに関数が起動・終了し、常駐プロセスや
+プロセス内メモリを持てない）なので、この構造とは根本的に噛み合わない。
+
+→ **常駐プロセスを動かせる PaaS**（Render / Railway / Fly.io 等）を使う。以下は Render 前提。
+
+---
+
+## 0. 前提
+
+- GitHub アカウント（このリポジトリ `tabear25/formula1_dashboard` にアクセスできること）
+- Render アカウント（GitHub でサインイン・無料枠あり）
+- API キーや課金は不要（FastF1 は公開データ）
+
+---
+
+## 1. デプロイするコードを対象ブランチに置く ⚠️最重要
+
+Render 用の設定（`render.yaml`）と `$PORT`/`0.0.0.0` 対応済みの `server.py` は
+作業ブランチにある。`main` にマージするか、Render 側で対象ブランチを直接指定する。
+
+対象ブランチに以下が存在することを確認:
+- `server.py`（`--host` / `--port $PORT` / `FASTF1_CACHE` 対応済み）
+- `render.yaml`（Render Blueprint）
+- `web/`（`index.html` / `styles.css` / `js/` 一式）
+- `requirements.txt`
+
+---
+
+## 2. Render でサービスを作成（Blueprint 推奨）
+
+1. Render ダッシュボード → **New +** → **Blueprint**。
+2. このリポジトリを選択。`render.yaml` が自動検出される。
+3. 内容を確認して **Apply**。以下の設定でデプロイされる:
+   - `runtime: python` / `plan: free`
+   - build: `pip install -r requirements.txt`
+   - start: `python server.py --host 0.0.0.0 --port $PORT --no-browser`
+   - env: `PYTHON_VERSION=3.11.9`, `FASTF1_CACHE=/tmp/f1_cache`
+
+Blueprint を使わず手動で作る場合は **New + → Web Service** を選び、
+Runtime=Python、Build/Start コマンドと環境変数を上記と同じに設定すればよい。
+
+---
+
+## 3. 動作確認
+
+- デプロイ完了後に払い出される `https://<service>.onrender.com/` を開く。
+- 年 → グランプリ → セッションを選んで「読み込み」。
+- **ローカルの `py server.py` と同じ画面**（ヘッダー / ドライバーチップ / スタッツ /
+  各タブの自前 SVG チャート）が出れば成功。
+
+---
+
+## 4. 無料枠の制約（重要）
+
+- **スリープ**: 無料 Web サービスは一定時間アクセスが無いと停止し、次アクセス時に
+  コールドスタート（数十秒〜）する。
+- **キャッシュ揮発**: `/tmp` は再デプロイ・スリープ復帰で消えるため、初回セッションの
+  FastF1 ダウンロード（数分かかることがある）が都度発生する。永続ディスク（Render の
+  Disk / 有料）を `FASTF1_CACHE` にマウントすれば高速化できる。
+- **メモリ**: 無料枠は RAM 512MB 程度。決勝のフルセッション（laps + telemetry）は
+  メモリを食うため、重いセッションで落ちる場合は有料インスタンスへ。
+
+---
+
+## 代替: Railway / Fly.io
+
+いずれも常駐プロセスを動かせる。起動コマンドは Render と同じ考え方:
+
+```
+python server.py --host 0.0.0.0 --port $PORT --no-browser
+```
+
+- **Railway**: リポジトリを接続し、Start Command に上記を設定。`$PORT` は自動注入。
+- **Fly.io**: `fly launch` で Python を検出。`fly.toml` の `internal_port` を `$PORT`
+  ではなく固定値にする場合は、Start Command 側もその値に合わせる。
+
+環境変数 `FASTF1_CACHE` を書き込み可能パスに向ける点は各社共通。

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,24 @@
+# Render Blueprint — PITWALL（Web版 F1 ダッシュボード）を常駐サーバとしてデプロイする。
+#
+# 使い方:
+#   1. このリポジトリを Render に接続し、Blueprint（render.yaml）からサービスを作成。
+#   2. デプロイ後に払い出される https://<service>.onrender.com/ を開く。
+#
+# ポイント:
+#   - PITWALL は stdlib http.server の常駐プロセス。サーバーレス（Vercel/Netlify）では
+#     動かないため Render/Railway/Fly 等の常駐プロセス対応 PaaS を使う。
+#   - Render は $PORT を注入する。server.py は $PORT / --host 0.0.0.0 に対応済み。
+#   - FASTF1_CACHE でキャッシュ先を書き込み可能パスに向ける（無料枠は永続化されないため
+#     再デプロイ／スリープ復帰でキャッシュは消える＝初回ロードが都度遅くなる点に注意）。
+services:
+  - type: web
+    name: pitwall-f1-dashboard
+    runtime: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: python server.py --host 0.0.0.0 --port $PORT --no-browser
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.11.9"
+      - key: FASTF1_CACHE
+        value: /tmp/f1_cache

--- a/server.py
+++ b/server.py
@@ -14,6 +14,7 @@ import gzip
 import json
 import logging
 import math
+import os
 import threading
 import time
 import traceback
@@ -833,22 +834,31 @@ class Handler(BaseHTTPRequestHandler):
 
 def main():
     parser = argparse.ArgumentParser(description="PITWALL - F1 web dashboard server")
-    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    # PaaS（Render 等）は $PORT / $HOST を注入する。ローカルは従来の既定値で動く。
+    parser.add_argument("--port", type=int,
+                        default=int(os.environ.get("PORT", DEFAULT_PORT)))
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"),
+                        help="バインドするホスト。PaaS では 0.0.0.0 を指定する。")
     parser.add_argument("--no-browser", action="store_true")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO,
                         format="[%(asctime)s] %(levelname)s %(message)s")
 
-    cache_path = Path(CACHE_DIR)
+    # キャッシュ先は環境変数 FASTF1_CACHE を優先（PaaS の書き込み可能パス）。
+    # 未設定時は config.CACHE_DIR（ローカルの _fastf1_cache/）。core/data.py と揃える。
+    cache_path = Path(os.environ.get("FASTF1_CACHE") or CACHE_DIR)
     cache_path.mkdir(parents=True, exist_ok=True)
     fastf1.Cache.enable_cache(str(cache_path))
     logging.info("FastF1 cache: %s", cache_path.resolve())
 
-    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
-    url = f"http://127.0.0.1:{args.port}/"
-    logging.info("PITWALL running at %s", url)
-    if not args.no_browser:
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    # 表示 URL はループバック系ならそのまま、0.0.0.0 バインド時は 127.0.0.1 に読み替える。
+    display_host = "127.0.0.1" if args.host in ("0.0.0.0", "") else args.host
+    url = f"http://{display_host}:{args.port}/"
+    logging.info("PITWALL running at %s (bind %s:%s)", url, args.host, args.port)
+    # ブラウザ自動起動はローカルのループバック時のみ（PaaS では開かない）。
+    if not args.no_browser and args.host in ("127.0.0.1", "localhost"):
         threading.Timer(0.8, lambda: webbrowser.open(url)).start()
     try:
         server.serve_forever()


### PR DESCRIPTION
## Summary

Enable the PITWALL web dashboard (`server.py` + `web/`) to be deployed on always-on PaaS platforms (Render, Railway, Fly.io) while maintaining identical local behavior. This allows users to access the same interactive SVG-based UI remotely without relying on serverless platforms (Vercel/Netlify), which cannot support PITWALL's persistent HTTP server + in-memory LRU cache architecture.

## Key Changes

- **`server.py`**: 
  - Added `--host` argument and `$HOST` environment variable support (defaults to `127.0.0.1` locally, accepts `0.0.0.0` for PaaS)
  - Modified `--port` to read from `$PORT` environment variable first (injected by PaaS), falling back to `DEFAULT_PORT` locally
  - Added `FASTF1_CACHE` environment variable support for cache directory (PaaS-friendly writable path like `/tmp/f1_cache`), with fallback to `config.CACHE_DIR`
  - Restricted browser auto-launch to loopback addresses only (`127.0.0.1`, `localhost`) — PaaS deployments use `--no-browser`
  - Display URL now intelligently shows `127.0.0.1` when binding to `0.0.0.0` (for user clarity)
  - Local behavior unchanged: `py server.py` still defaults to `127.0.0.1:8380` with auto-launch

- **`render.yaml`** (new):
  - Render Blueprint configuration for one-click deployment
  - Runtime: Python 3.11.9
  - Build: `pip install -r requirements.txt`
  - Start: `python server.py --host 0.0.0.0 --port $PORT --no-browser`
  - Environment: `FASTF1_CACHE=/tmp/f1_cache` (note: ephemeral on free tier)

- **`DEPLOY_PITWALL.md`** (new):
  - Complete deployment guide for Render (Blueprint + manual setup)
  - Explanation of why Vercel/Netlify cannot work (serverless incompatibility with persistent processes)
  - Alternative PaaS options (Railway, Fly.io) with equivalent configuration
  - Free tier constraints: sleep/cold-start, `/tmp` cache volatility, 512MB memory limits
  - Troubleshooting and upgrade paths

- **`CLAUDE.md`**: 
  - Updated change log with deployment enablement details and verification notes

## Implementation Details

- Environment variable precedence: `$PORT` / `$HOST` / `FASTF1_CACHE` override defaults, enabling PaaS injection without code changes
- Backward compatible: local `py server.py` invocation is unaffected
- Cache path consistency: aligns with `core/data.py` expectations
- Verified: syntax check, argument/env resolution, actual startup with `--host 0.0.0.0 --port $PORT`, static asset serving (200 responses), cache path logging

https://claude.ai/code/session_012ojpnCpWu9BmhZBELJiQPj